### PR TITLE
update serverless-offline to version supporting python

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker run -it -p 9324:9324 s12v/elasticmq:latest
 
 ```
 
-Queues will be automatically created.
+Queues will be automatically created. The QueueUrl for a SendMessage command sent by a client would be `http://0.0.0.0:9324/queue/MyQueue`.
 
 
 ## Roadmap

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "aws-sdk": "^2.271.1",
     "figures": "^2.0.0",
     "lodash": "^4.17.10",
-    "serverless-offline": "4.0.0"
+    "serverless-offline": "4.9.4"
   },
   "keywords": [
     "sqs",

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,8 @@ class ServerlessOfflineSQS {
 
     const servicePath = join(this.serverless.config.servicePath, location);
     console.log(servicePath)
-    const funOptions = getFunctionOptions(__function, functionName, servicePath);
+    const serviceRuntime = this.service.provider.runtime;
+    const funOptions = getFunctionOptions(__function, functionName, servicePath, serviceRuntime);
     const handler = createHandler(funOptions, Object.assign({}, this.options, this.config));
 
     const lambdaContext = createLambdaContext(__function, (err, data) => {
@@ -133,7 +134,7 @@ class ServerlessOfflineSQS {
       )
     };
 
-    if (handler.length < 3)
+    if (serviceRuntime.startsWith('node') && handler.length < 3)
       handler(event, lambdaContext)
         .then(res => lambdaContext.done(null, res))
         .catch(lambdaContext.done);


### PR DESCRIPTION
- Upgrade serverless-offline to 4.9.4 to allow support of python and ruby. 
- Added clarification for QueueUrl to be used by SendMessage